### PR TITLE
Pull upstream fixes 

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -425,7 +425,7 @@ jobs:
           tar -czf sprint-int-test-logs.tar.gz test_run_root/* ws_test_run_root/*
 
       - name: Upload logs from failed tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: spring-int-test-logs.tar.gz

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -124,7 +124,7 @@ jobs:
           CXX: g++-11
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build.tar.gz
           path: build.tar.gz
@@ -280,7 +280,7 @@ jobs:
           ref: '${{needs.versions.outputs.eos-evm-miner-target}}'
 
       - name: Download EOS EVM Node builddir
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build.tar.gz
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ include(cmake/conan.cmake)
 
 set(VERSION_MAJOR 1)
 set(VERSION_MINOR 0)
-set(VERSION_PATCH 5)
+set(VERSION_PATCH 6)
 #set(VERSION_SUFFIX rc4)
 
 if(VERSION_SUFFIX)


### PR DESCRIPTION
Mainly for https://github.com/eosnetworkfoundation/eos-evm-node/issues/355

Should be safe not to upgrade to this version for a while when we are waiting for audit